### PR TITLE
Enhanced protection from memory leaks

### DIFF
--- a/dist/esm/index.d.mts
+++ b/dist/esm/index.d.mts
@@ -3,7 +3,7 @@ export declare const serdesSerializeSymbol: unique symbol;
 export declare const serdesDeserializeSymbol: unique symbol;
 type Transferables = MessagePort | ReadableStream | WritableStream | ArrayBuffer | ArrayBufferView;
 type Revokables = MessagePort;
-export declare const serializer: (data: unknown) => {
+export declare const serializer: (data: unknown, noFn?: boolean) => {
     data: unknown;
     transferables: Transferables[];
     revokables: Revokables[];

--- a/dist/esm/index.js
+++ b/dist/esm/index.js
@@ -47,147 +47,159 @@ export const serializer = (data, noFn) => {
     const revokables = new Set();
     // JSON.parse and JSON.stringify are called for their ability to do a deep
     // clone and calling a reviver / replacer.
-    const result = JSON.parse(JSON.stringify(data, (_key, value) => {
-        // Return already processed values without modifications
-        if (value && typeof value === 'object' && rawResultSet.has(value))
-            return value;
-        // Encode undefined as ['_', '_']
-        if (value === undefined)
-            return rawResult(rawResultSet, ['_', '_']);
-        // Encode falsy values as they are (JSON.stringify can handle these well,
-        // except undefined, which can't be represented in JSON)
-        if (!value)
-            return value;
-        // Arrays starting with '_' hold special (internal) meaning. If we receive
-        // such a value to encode, we prepend '_', '_' to ensure they are properly
-        // handled (this will be undone when deserializing)
-        if (Array.isArray(value) && value[0] === '_')
-            return rawResult(rawResultSet, ['_', '_', ...value]);
-        // If something is a Map, encode it as such. It needs to be broken down into
-        // an array so that elements they contain can also be processed, since JSON
-        // does not support Map
-        if (value instanceof Map) {
-            return rawResult(rawResultSet, ['_', 'Map', Array.from(value.entries())]);
-        }
-        // Same for Sets
-        if (value instanceof Set) {
-            return rawResult(rawResultSet, ['_', 'Set', Array.from(value.values())]);
-        }
-        // Error, Blob, File, etc. are supported by structuredClone but not by JSON
-        // We mark these as 'refs', so that the reviver can undo this transformation
-        if (value instanceof Blob || value instanceof File) {
-            const pos = verbatim.length;
-            verbatim[verbatim.length] = value;
-            return rawResult(rawResultSet, ['_', '_ref', pos]);
-        }
-        // However, Error cloning doesn't preserve `.name`
-        if (value instanceof Error) {
-            const obj = (() => {
-                if (value.cause) {
-                    const causeCopy = value.cause;
-                    let serialized;
+    try {
+        const result = JSON.parse(JSON.stringify(data, (_key, value) => {
+            // Return already processed values without modifications
+            if (value && typeof value === 'object' && rawResultSet.has(value))
+                return value;
+            // Encode undefined as ['_', '_']
+            if (value === undefined)
+                return rawResult(rawResultSet, ['_', '_']);
+            // Encode falsy values as they are (JSON.stringify can handle these well,
+            // except undefined, which can't be represented in JSON)
+            if (!value)
+                return value;
+            // Arrays starting with '_' hold special (internal) meaning. If we receive
+            // such a value to encode, we prepend '_', '_' to ensure they are properly
+            // handled (this will be undone when deserializing)
+            if (Array.isArray(value) && value[0] === '_')
+                return rawResult(rawResultSet, ['_', '_', ...value]);
+            // If something is a Map, encode it as such. It needs to be broken down into
+            // an array so that elements they contain can also be processed, since JSON
+            // does not support Map
+            if (value instanceof Map) {
+                return rawResult(rawResultSet, ['_', 'Map', Array.from(value.entries())]);
+            }
+            // Same for Sets
+            if (value instanceof Set) {
+                return rawResult(rawResultSet, ['_', 'Set', Array.from(value.values())]);
+            }
+            // Error, Blob, File, etc. are supported by structuredClone but not by JSON
+            // We mark these as 'refs', so that the reviver can undo this transformation
+            if (value instanceof Blob || value instanceof File) {
+                const pos = verbatim.length;
+                verbatim[verbatim.length] = value;
+                return rawResult(rawResultSet, ['_', '_ref', pos]);
+            }
+            // However, Error cloning doesn't preserve `.name`
+            if (value instanceof Error) {
+                const obj = (() => {
+                    if (value.cause) {
+                        const causeCopy = value.cause;
+                        let serialized;
+                        try {
+                            // We need to also serialize `Error.cause` recursively
+                            // Do it on a copy so that the original object isn't destructively
+                            // modified
+                            // structuredClone will fail if `cause` has something that it doesn't
+                            // support
+                            serialized = serializer(value.cause, true);
+                            value.cause = serialized.data;
+                            const copy = structuredClone(value);
+                            serialized.transferables.forEach(t => transferables.add(t));
+                            serialized.revokables.forEach(r => revokables.add(r));
+                            return copy;
+                        }
+                        catch (e) {
+                            console.error('Error serializing error cause', e);
+                            serialized?.revokables.forEach(r => r.close());
+                            // Add a fallback that preserves the error's key details
+                            const fallback = new Error(value.message);
+                            return fallback;
+                        }
+                        finally {
+                            value.cause = causeCopy;
+                        }
+                    }
+                    else {
+                        return value;
+                    }
+                })();
+                const pos = verbatim.length;
+                verbatim[verbatim.length] = obj;
+                return rawResult(rawResultSet, ['_', '_err', rawResult(rawResultSet, ['_', '_ref', pos]), value.name]);
+            }
+            // Same for other types supported by structuredClone but not JSON
+            if (value instanceof MessagePort || value instanceof ReadableStream || value instanceof WritableStream || value instanceof ArrayBuffer) {
+                const pos = verbatim.length;
+                verbatim[verbatim.length] = value;
+                transferables.add(value);
+                return rawResult(rawResultSet, ['_', '_ref', pos]);
+            }
+            if (ArrayBuffer.isView(value)) {
+                const pos = verbatim.length;
+                verbatim[verbatim.length] = value;
+                if (!(typeof SharedArrayBuffer === 'function' && value.buffer instanceof SharedArrayBuffer)) {
+                    transferables.add(value.buffer);
+                }
+                return rawResult(rawResultSet, ['_', '_ref', pos]);
+            }
+            // Functions aren't supported neither by structuredClone nor JSON. However,
+            // we can convert functions into a MessagePort, which is supported
+            // To prevent memory leaks, it is important to fetch the `revokables` list
+            // and close ports when they are no longer needed.
+            if (typeof value === 'function' && !noFn) {
+                const mc = new MessageChannel();
+                mc.port1.onmessage = async (ev) => {
                     try {
-                        // We need to also serialize `Error.cause` recursively
-                        // Do it on a copy so that the original object isn't destructively
-                        // modified
-                        // structuredClone will fail if `cause` has something that it doesn't
-                        // support
-                        serialized = serializer(value.cause, true);
-                        value.cause = serialized.data;
-                        const copy = structuredClone(value);
-                        serialized.transferables.forEach(t => transferables.add(t));
-                        serialized.revokables.forEach(r => revokables.add(r));
-                        return copy;
+                        try {
+                            const result = await value(...deserializer(ev.data[1]));
+                            const { data, transferables, revokables } = serializer(result);
+                            try {
+                                ev.data[0].postMessage([true, data], transferables);
+                            }
+                            catch (e) {
+                                revokables.forEach(port => port.close());
+                                throw e;
+                            }
+                        }
+                        catch (e) {
+                            try {
+                                const { data, transferables } = serializer(e, true);
+                                ev.data[0].postMessage([false, data], transferables);
+                            }
+                            catch (e) {
+                                console.error('Error on onmessage handler trying to transmit error', e);
+                                ev.data[0].postMessage([false]);
+                            }
+                        }
                     }
                     catch (e) {
-                        console.error('Error serializing error cause', e);
-                        serialized?.revokables.forEach(r => r.close());
+                        console.error('Async error on onmessage handler', e);
                     }
                     finally {
-                        value.cause = causeCopy;
+                        ev.data[0].close();
                     }
-                }
-                else {
-                    return value;
-                }
-            })();
-            const pos = verbatim.length;
-            verbatim[verbatim.length] = obj || Error('Error');
-            return rawResult(rawResultSet, ['_', '_err', rawResult(rawResultSet, ['_', '_ref', pos]), value.name]);
-        }
-        // Same for other types supported by structuredClone but not JSON
-        if (value instanceof MessagePort || value instanceof ReadableStream || value instanceof WritableStream || value instanceof ArrayBuffer) {
-            const pos = verbatim.length;
-            verbatim[verbatim.length] = value;
-            transferables.add(value);
-            return rawResult(rawResultSet, ['_', '_ref', pos]);
-        }
-        if (ArrayBuffer.isView(value)) {
-            const pos = verbatim.length;
-            verbatim[verbatim.length] = value;
-            if (!(typeof SharedArrayBuffer === 'function' && value.buffer instanceof SharedArrayBuffer)) {
-                transferables.add(value.buffer);
+                };
+                transferables.add(mc.port2);
+                revokables.add(mc.port1);
+                return rawResult(rawResultSet, ['_', '_fn', mc.port2]);
             }
-            return rawResult(rawResultSet, ['_', '_ref', pos]);
-        }
-        // Functions aren't supported neither by structuredClone nor JSON. However,
-        // we can convert functions into a MessagePort, which is supported
-        // To prevent memory leaks, it is important to fetch the `revokables` list
-        // and close ports when they are no longer needed.
-        if (typeof value === 'function' && !noFn) {
-            const mc = new MessageChannel();
-            mc.port1.onmessage = async (ev) => {
-                try {
-                    try {
-                        const result = await value(...deserializer(ev.data[1]));
-                        const { data, transferables, revokables } = serializer(result);
-                        try {
-                            ev.data[0].postMessage([true, data], transferables);
-                        }
-                        catch (e) {
-                            revokables.forEach(port => port.close());
-                            throw e;
-                        }
-                    }
-                    catch (e) {
-                        try {
-                            const { data, transferables } = serializer(e, true);
-                            ev.data[0].postMessage([false, data], transferables);
-                        }
-                        catch (e) {
-                            console.error('Error on onmessage handler trying to transmit error', e);
-                            ev.data[0].postMessage([false]);
-                        }
-                    }
-                    ev.data[0].close();
-                }
-                catch (e) {
-                    console.error('Async error on onmessage handler', e);
-                }
-            };
-            transferables.add(mc.port2);
-            revokables.add(mc.port1);
-            return rawResult(rawResultSet, ['_', '_fn', mc.port2]);
-        }
-        const proto = Object.getPrototypeOf(value);
-        // This allows encoding custom arbitrary objects (e.g., GIMessage)
-        if (proto?.constructor?.[serdesTagSymbol] && proto.constructor[serdesSerializeSymbol]) {
-            return rawResult(rawResultSet, ['_', '_custom', proto.constructor[serdesTagSymbol], proto.constructor[serdesSerializeSymbol](value)]);
-        }
-        return value;
-    }), (_key, value) => {
-        // Undo _ref transformations so that structuredClone can send the correct
-        // object
-        if (Array.isArray(value) && value[0] === '_' && value[1] === '_ref') {
-            return verbatim[value[2]];
-        }
-        return value;
-    });
-    return {
-        data: result,
-        transferables: Array.from(transferables),
-        revokables: Array.from(revokables)
-    };
+            const proto = Object.getPrototypeOf(value);
+            // This allows encoding custom arbitrary objects (e.g., GIMessage)
+            if (proto?.constructor?.[serdesTagSymbol] && proto.constructor[serdesSerializeSymbol]) {
+                return rawResult(rawResultSet, ['_', '_custom', proto.constructor[serdesTagSymbol], proto.constructor[serdesSerializeSymbol](value)]);
+            }
+            return value;
+        }), (_key, value) => {
+            // Undo _ref transformations so that structuredClone can send the correct
+            // object
+            if (Array.isArray(value) && value[0] === '_' && value[1] === '_ref') {
+                return verbatim[value[2]];
+            }
+            return value;
+        });
+        return {
+            data: result,
+            transferables: Array.from(transferables),
+            revokables: Array.from(revokables)
+        };
+    }
+    catch (e) {
+        // Prevent memory leaks if stringify aborts cleanly mid-traversal
+        revokables.forEach(port => port.close());
+        throw e;
+    }
 };
 // Internal lookup table for registered deserializers
 const deserializerTable = Object.create(null);

--- a/dist/esm/index.js
+++ b/dist/esm/index.js
@@ -24,6 +24,24 @@ const rawResult = (rawResultSet, obj) => {
     rawResultSet.add(obj);
     return obj;
 };
+const portDestructor = (() => {
+    if (typeof FinalizationRegistry !== 'function' || typeof WeakRef !== 'function') {
+        return () => { };
+    }
+    const registry = new FinalizationRegistry((heldValue) => {
+        heldValue();
+    });
+    // Automatic destruction (handled on the deserializing end):
+    // When a returned proxy function goes out of scope, close its associated port
+    return (fn, port) => {
+        // Using a weak reference to prevent leaking memory
+        const portWR = new WeakRef(port);
+        registry.register(fn, () => {
+            const port = portWR.deref();
+            port?.close();
+        });
+    };
+})();
 // The `serializer` function prepares data before sending it as a message
 // The `noFn` boolean disables serializing functions, which helps with
 // memory management.
@@ -84,7 +102,7 @@ export const serializer = (data, noFn) => {
             transferables.add(value);
             return rawResult(rawResultSet, ['_', '_ref', pos]);
         }
-        if (ArrayBuffer.isView(value) && !(typeof SharedArrayBuffer !== 'function' || value.buffer instanceof SharedArrayBuffer)) {
+        if (ArrayBuffer.isView(value) && !(typeof SharedArrayBuffer === 'function' && value.buffer instanceof SharedArrayBuffer)) {
             const pos = verbatim.length;
             verbatim[verbatim.length] = value;
             transferables.add(value.buffer);
@@ -92,23 +110,22 @@ export const serializer = (data, noFn) => {
         }
         // Functions aren't supported neither by structuredClone nor JSON. However,
         // we can convert functions into a MessagePort, which is supported
+        // To prevent memory leaks, it is important to fetch the `revokables` list
+        // and close ports when they are no longer needed.
         if (typeof value === 'function' && !noFn) {
             const mc = new MessageChannel();
             mc.port1.onmessage = async (ev) => {
                 try {
                     try {
                         const result = await value(...deserializer(ev.data[1]));
-                        // TODO FIXME: This could still leave some ports open on functions
-                        // that return functions that return functions
-                        const { data, transferables, revokables: rr } = serializer(result);
+                        const { data, transferables } = serializer(result);
                         ev.data[0].postMessage([true, data], transferables);
-                        rr.forEach(r => revokables.add(r));
                     }
                     catch (e) {
-                        const { data, transferables, revokables: rr } = serializer(e, true);
+                        const { data, transferables } = serializer(e, true);
                         ev.data[0].postMessage([false, data], transferables);
-                        rr.forEach(r => revokables.add(r));
                     }
+                    ev.data[0].close();
                 }
                 catch (e) {
                     console.error('Async error on onmessage handler', e);
@@ -195,25 +212,37 @@ export const deserializer = (data) => {
                 // end back into functions using that port.
                 case '_fn': {
                     const mp = value[2];
-                    return (...args) => {
+                    const fn = (...args) => {
                         return new Promise((resolve, reject) => {
                             const mc = new MessageChannel();
-                            // TODO FIXME: Potential memory leak if any of the args is a
-                            // function that gets called. This level of nesting isn't
-                            // that common. A more comprehensive solution should nevertheless
-                            // be devised.
                             const { data, transferables } = serializer(args);
-                            mc.port1.onmessage = (ev) => {
+                            const rcvPort = mc.port1;
+                            const sendingPort = mc.port2;
+                            rcvPort.onmessage = (ev) => {
                                 if (ev.data[0]) {
                                     resolve(deserializer(ev.data[1]));
                                 }
                                 else {
                                     reject(deserializer(ev.data[1]));
                                 }
+                                rcvPort.close();
                             };
-                            mp.postMessage([mc.port2, data], [mc.port2, ...transferables]);
+                            rcvPort.onmessageerror = () => {
+                                reject(new Error('Message error'));
+                                rcvPort.close();
+                            };
+                            try {
+                                mp.postMessage([sendingPort, data], [sendingPort, ...transferables]);
+                            }
+                            catch (e) {
+                                rcvPort.close();
+                                reject(e);
+                            }
                         });
                     };
+                    // Automatic clean up when the function goes out of scope
+                    portDestructor(fn, mp);
+                    return fn;
                 }
             }
         }

--- a/dist/esm/index.js
+++ b/dist/esm/index.js
@@ -111,10 +111,12 @@ export const serializer = (data, noFn) => {
             transferables.add(value);
             return rawResult(rawResultSet, ['_', '_ref', pos]);
         }
-        if (ArrayBuffer.isView(value) && !(typeof SharedArrayBuffer === 'function' && value.buffer instanceof SharedArrayBuffer)) {
+        if (ArrayBuffer.isView(value)) {
             const pos = verbatim.length;
             verbatim[verbatim.length] = value;
-            transferables.add(value.buffer);
+            if (!(typeof SharedArrayBuffer === 'function' && value.buffer instanceof SharedArrayBuffer)) {
+                transferables.add(value.buffer);
+            }
             return rawResult(rawResultSet, ['_', '_ref', pos]);
         }
         // Functions aren't supported neither by structuredClone nor JSON. However,
@@ -137,8 +139,14 @@ export const serializer = (data, noFn) => {
                         }
                     }
                     catch (e) {
-                        const { data, transferables } = serializer(e, true);
-                        ev.data[0].postMessage([false, data], transferables);
+                        try {
+                            const { data, transferables } = serializer(e, true);
+                            ev.data[0].postMessage([false, data], transferables);
+                        }
+                        catch (e) {
+                            console.error('Error on onmessage handler trying to transmit error', e);
+                            ev.data[0].postMessage([false]);
+                        }
                     }
                     ev.data[0].close();
                 }
@@ -234,17 +242,27 @@ export const deserializer = (data) => {
                             const rcvPort = mc.port1;
                             const sendingPort = mc.port2;
                             rcvPort.onmessage = (ev) => {
-                                if (ev.data[0]) {
-                                    resolve(deserializer(ev.data[1]));
+                                try {
+                                    if (ev.data[0]) {
+                                        resolve(deserializer(ev.data[1]));
+                                    }
+                                    else {
+                                        reject(deserializer(ev.data[1]));
+                                    }
                                 }
-                                else {
-                                    reject(deserializer(ev.data[1]));
+                                finally {
+                                    rcvPort.close();
+                                    revokables.forEach(port => port.close());
                                 }
-                                rcvPort.close();
                             };
                             rcvPort.onmessageerror = () => {
-                                reject(new Error('Message error'));
-                                rcvPort.close();
+                                try {
+                                    reject(new Error('Message error'));
+                                }
+                                finally {
+                                    rcvPort.close();
+                                    revokables.forEach(port => port.close());
+                                }
                             };
                             try {
                                 mp.postMessage([sendingPort, data], [sendingPort, ...transferables]);

--- a/dist/esm/index.js
+++ b/dist/esm/index.js
@@ -25,7 +25,9 @@ const rawResult = (rawResultSet, obj) => {
     return obj;
 };
 // The `serializer` function prepares data before sending it as a message
-export const serializer = (data) => {
+// The `noFn` boolean disables serializing functions, which helps with
+// memory management.
+export const serializer = (data, noFn) => {
     const rawResultSet = new WeakSet();
     const verbatim = [];
     const transferables = new Set();
@@ -71,7 +73,7 @@ export const serializer = (data) => {
             verbatim[verbatim.length] = value;
             // We need to also serialize `Error.cause` recursively
             if (value.cause) {
-                value.cause = serializer(value.cause).data;
+                value.cause = serializer(value.cause, true).data;
             }
             return rawResult(rawResultSet, ['_', '_err', rawResult(rawResultSet, ['_', '_ref', pos]), value.name]);
         }
@@ -82,7 +84,7 @@ export const serializer = (data) => {
             transferables.add(value);
             return rawResult(rawResultSet, ['_', '_ref', pos]);
         }
-        if (ArrayBuffer.isView(value)) {
+        if (ArrayBuffer.isView(value) && !(typeof SharedArrayBuffer !== 'function' || value.buffer instanceof SharedArrayBuffer)) {
             const pos = verbatim.length;
             verbatim[verbatim.length] = value;
             transferables.add(value.buffer);
@@ -90,18 +92,22 @@ export const serializer = (data) => {
         }
         // Functions aren't supported neither by structuredClone nor JSON. However,
         // we can convert functions into a MessagePort, which is supported
-        if (typeof value === 'function') {
+        if (typeof value === 'function' && !noFn) {
             const mc = new MessageChannel();
             mc.port1.onmessage = async (ev) => {
                 try {
                     try {
                         const result = await value(...deserializer(ev.data[1]));
-                        const { data, transferables } = serializer(result);
+                        // TODO FIXME: This could still leave some ports open on functions
+                        // that return functions that return functions
+                        const { data, transferables, revokables: rr } = serializer(result);
                         ev.data[0].postMessage([true, data], transferables);
+                        rr.forEach(r => revokables.add(r));
                     }
                     catch (e) {
-                        const { data, transferables } = serializer(e);
+                        const { data, transferables, revokables: rr } = serializer(e, true);
                         ev.data[0].postMessage([false, data], transferables);
+                        rr.forEach(r => revokables.add(r));
                     }
                 }
                 catch (e) {
@@ -192,6 +198,10 @@ export const deserializer = (data) => {
                     return (...args) => {
                         return new Promise((resolve, reject) => {
                             const mc = new MessageChannel();
+                            // TODO FIXME: Potential memory leak if any of the args is a
+                            // function that gets called. This level of nesting isn't
+                            // that common. A more comprehensive solution should nevertheless
+                            // be devised.
                             const { data, transferables } = serializer(args);
                             mc.port1.onmessage = (ev) => {
                                 if (ev.data[0]) {

--- a/dist/esm/index.js
+++ b/dist/esm/index.js
@@ -25,7 +25,7 @@ const rawResult = (rawResultSet, obj) => {
     return obj;
 };
 const portDestructor = (() => {
-    if (typeof FinalizationRegistry !== 'function' || typeof WeakRef !== 'function') {
+    if (typeof FinalizationRegistry !== 'function') {
         return () => { };
     }
     const registry = new FinalizationRegistry((heldValue) => {
@@ -85,12 +85,23 @@ export const serializer = (data, noFn) => {
             const obj = (() => {
                 if (value.cause) {
                     const causeCopy = value.cause;
+                    let serialized;
                     try {
                         // We need to also serialize `Error.cause` recursively
                         // Do it on a copy so that the original object isn't destructively
                         // modified
-                        value.cause = serializer(value.cause, true).data;
-                        return structuredClone(value);
+                        // structuredClone will fail if `cause` has something that it doesn't
+                        // support
+                        serialized = serializer(value.cause, true);
+                        value.cause = serialized.data;
+                        const copy = structuredClone(value);
+                        serialized.transferables.forEach(t => transferables.add(t));
+                        serialized.revokables.forEach(r => revokables.add(r));
+                        return copy;
+                    }
+                    catch (e) {
+                        console.error('Error serializing error cause', e);
+                        serialized?.revokables.forEach(r => r.close());
                     }
                     finally {
                         value.cause = causeCopy;
@@ -101,7 +112,7 @@ export const serializer = (data, noFn) => {
                 }
             })();
             const pos = verbatim.length;
-            verbatim[verbatim.length] = obj;
+            verbatim[verbatim.length] = obj || Error('Error');
             return rawResult(rawResultSet, ['_', '_err', rawResult(rawResultSet, ['_', '_ref', pos]), value.name]);
         }
         // Same for other types supported by structuredClone but not JSON
@@ -247,8 +258,11 @@ export const deserializer = (data) => {
                                         resolve(deserializer(ev.data[1]));
                                     }
                                     else {
-                                        reject(deserializer(ev.data[1]));
+                                        reject(ev.data.length > 1 ? deserializer(ev.data[1]) : new Error('Message error'));
                                     }
+                                }
+                                catch (e) {
+                                    reject(e);
                                 }
                                 finally {
                                     rcvPort.close();

--- a/dist/esm/index.js
+++ b/dist/esm/index.js
@@ -29,17 +29,12 @@ const portDestructor = (() => {
         return () => { };
     }
     const registry = new FinalizationRegistry((heldValue) => {
-        heldValue();
+        heldValue.close();
     });
     // Automatic destruction (handled on the deserializing end):
     // When a returned proxy function goes out of scope, close its associated port
     return (fn, port) => {
-        // Using a weak reference to prevent leaking memory
-        const portWR = new WeakRef(port);
-        registry.register(fn, () => {
-            const port = portWR.deref();
-            port?.close();
-        });
+        registry.register(fn, port);
     };
 })();
 // The `serializer` function prepares data before sending it as a message
@@ -87,12 +82,26 @@ export const serializer = (data, noFn) => {
         }
         // However, Error cloning doesn't preserve `.name`
         if (value instanceof Error) {
+            const obj = (() => {
+                if (value.cause) {
+                    const causeCopy = value.cause;
+                    try {
+                        // We need to also serialize `Error.cause` recursively
+                        // Do it on a copy so that the original object isn't destructively
+                        // modified
+                        value.cause = serializer(value.cause, true).data;
+                        return structuredClone(value);
+                    }
+                    finally {
+                        value.cause = causeCopy;
+                    }
+                }
+                else {
+                    return value;
+                }
+            })();
             const pos = verbatim.length;
-            verbatim[verbatim.length] = value;
-            // We need to also serialize `Error.cause` recursively
-            if (value.cause) {
-                value.cause = serializer(value.cause, true).data;
-            }
+            verbatim[verbatim.length] = obj;
             return rawResult(rawResultSet, ['_', '_err', rawResult(rawResultSet, ['_', '_ref', pos]), value.name]);
         }
         // Same for other types supported by structuredClone but not JSON
@@ -118,8 +127,14 @@ export const serializer = (data, noFn) => {
                 try {
                     try {
                         const result = await value(...deserializer(ev.data[1]));
-                        const { data, transferables } = serializer(result);
-                        ev.data[0].postMessage([true, data], transferables);
+                        const { data, transferables, revokables } = serializer(result);
+                        try {
+                            ev.data[0].postMessage([true, data], transferables);
+                        }
+                        catch (e) {
+                            revokables.forEach(port => port.close());
+                            throw e;
+                        }
                     }
                     catch (e) {
                         const { data, transferables } = serializer(e, true);
@@ -215,7 +230,7 @@ export const deserializer = (data) => {
                     const fn = (...args) => {
                         return new Promise((resolve, reject) => {
                             const mc = new MessageChannel();
-                            const { data, transferables } = serializer(args);
+                            const { data, transferables, revokables } = serializer(args);
                             const rcvPort = mc.port1;
                             const sendingPort = mc.port2;
                             rcvPort.onmessage = (ev) => {
@@ -236,6 +251,7 @@ export const deserializer = (data) => {
                             }
                             catch (e) {
                                 rcvPort.close();
+                                revokables.forEach(port => port.close());
                                 reject(e);
                             }
                         });

--- a/dist/umd/index.cjs
+++ b/dist/umd/index.cjs
@@ -36,6 +36,19 @@
         rawResultSet.add(obj);
         return obj;
     };
+    const portDestructor = (() => {
+        if (typeof FinalizationRegistry !== 'function' || typeof WeakRef !== 'function') {
+            return () => { };
+        }
+        const registry = new FinalizationRegistry((heldValue) => {
+            heldValue.close();
+        });
+        // Automatic destruction (handled on the deserializing end):
+        // When a returned proxy function goes out of scope, close its associated port
+        return (fn, port) => {
+            registry.register(fn, port);
+        };
+    })();
     // The `serializer` function prepares data before sending it as a message
     // The `noFn` boolean disables serializing functions, which helps with
     // memory management.
@@ -81,12 +94,26 @@
             }
             // However, Error cloning doesn't preserve `.name`
             if (value instanceof Error) {
+                const obj = (() => {
+                    if (value.cause) {
+                        const causeCopy = value.cause;
+                        try {
+                            // We need to also serialize `Error.cause` recursively
+                            // Do it on a copy so that the original object isn't destructively
+                            // modified
+                            value.cause = (0, exports.serializer)(value.cause, true).data;
+                            return structuredClone(value);
+                        }
+                        finally {
+                            value.cause = causeCopy;
+                        }
+                    }
+                    else {
+                        return value;
+                    }
+                })();
                 const pos = verbatim.length;
-                verbatim[verbatim.length] = value;
-                // We need to also serialize `Error.cause` recursively
-                if (value.cause) {
-                    value.cause = (0, exports.serializer)(value.cause, true).data;
-                }
+                verbatim[verbatim.length] = obj;
                 return rawResult(rawResultSet, ['_', '_err', rawResult(rawResultSet, ['_', '_ref', pos]), value.name]);
             }
             // Same for other types supported by structuredClone but not JSON
@@ -96,7 +123,7 @@
                 transferables.add(value);
                 return rawResult(rawResultSet, ['_', '_ref', pos]);
             }
-            if (ArrayBuffer.isView(value) && !(typeof SharedArrayBuffer !== 'function' || value.buffer instanceof SharedArrayBuffer)) {
+            if (ArrayBuffer.isView(value) && !(typeof SharedArrayBuffer === 'function' && value.buffer instanceof SharedArrayBuffer)) {
                 const pos = verbatim.length;
                 verbatim[verbatim.length] = value;
                 transferables.add(value.buffer);
@@ -104,23 +131,28 @@
             }
             // Functions aren't supported neither by structuredClone nor JSON. However,
             // we can convert functions into a MessagePort, which is supported
+            // To prevent memory leaks, it is important to fetch the `revokables` list
+            // and close ports when they are no longer needed.
             if (typeof value === 'function' && !noFn) {
                 const mc = new MessageChannel();
                 mc.port1.onmessage = async (ev) => {
                     try {
                         try {
                             const result = await value(...(0, exports.deserializer)(ev.data[1]));
-                            // TODO FIXME: This could still leave some ports open on functions
-                            // that return functions that return functions
-                            const { data, transferables, revokables: rr } = (0, exports.serializer)(result);
-                            ev.data[0].postMessage([true, data], transferables);
-                            rr.forEach(r => revokables.add(r));
+                            const { data, transferables, revokables } = (0, exports.serializer)(result);
+                            try {
+                                ev.data[0].postMessage([true, data], transferables);
+                            }
+                            catch (e) {
+                                revokables.forEach(port => port.close());
+                                throw e;
+                            }
                         }
                         catch (e) {
-                            const { data, transferables, revokables: rr } = (0, exports.serializer)(e, true);
+                            const { data, transferables } = (0, exports.serializer)(e, true);
                             ev.data[0].postMessage([false, data], transferables);
-                            rr.forEach(r => revokables.add(r));
                         }
+                        ev.data[0].close();
                     }
                     catch (e) {
                         console.error('Async error on onmessage handler', e);
@@ -208,25 +240,38 @@
                     // end back into functions using that port.
                     case '_fn': {
                         const mp = value[2];
-                        return (...args) => {
+                        const fn = (...args) => {
                             return new Promise((resolve, reject) => {
                                 const mc = new MessageChannel();
-                                // TODO FIXME: Potential memory leak if any of the args is a
-                                // function that gets called. This level of nesting isn't
-                                // that common. A more comprehensive solution should nevertheless
-                                // be devised.
-                                const { data, transferables } = (0, exports.serializer)(args);
-                                mc.port1.onmessage = (ev) => {
+                                const { data, transferables, revokables } = (0, exports.serializer)(args);
+                                const rcvPort = mc.port1;
+                                const sendingPort = mc.port2;
+                                rcvPort.onmessage = (ev) => {
                                     if (ev.data[0]) {
                                         resolve((0, exports.deserializer)(ev.data[1]));
                                     }
                                     else {
                                         reject((0, exports.deserializer)(ev.data[1]));
                                     }
+                                    rcvPort.close();
                                 };
-                                mp.postMessage([mc.port2, data], [mc.port2, ...transferables]);
+                                rcvPort.onmessageerror = () => {
+                                    reject(new Error('Message error'));
+                                    rcvPort.close();
+                                };
+                                try {
+                                    mp.postMessage([sendingPort, data], [sendingPort, ...transferables]);
+                                }
+                                catch (e) {
+                                    rcvPort.close();
+                                    revokables.forEach(port => port.close());
+                                    reject(e);
+                                }
                             });
                         };
+                        // Automatic clean up when the function goes out of scope
+                        portDestructor(fn, mp);
+                        return fn;
                     }
                 }
             }

--- a/dist/umd/index.cjs
+++ b/dist/umd/index.cjs
@@ -123,10 +123,12 @@
                 transferables.add(value);
                 return rawResult(rawResultSet, ['_', '_ref', pos]);
             }
-            if (ArrayBuffer.isView(value) && !(typeof SharedArrayBuffer === 'function' && value.buffer instanceof SharedArrayBuffer)) {
+            if (ArrayBuffer.isView(value)) {
                 const pos = verbatim.length;
                 verbatim[verbatim.length] = value;
-                transferables.add(value.buffer);
+                if (!(typeof SharedArrayBuffer === 'function' && value.buffer instanceof SharedArrayBuffer)) {
+                    transferables.add(value.buffer);
+                }
                 return rawResult(rawResultSet, ['_', '_ref', pos]);
             }
             // Functions aren't supported neither by structuredClone nor JSON. However,
@@ -149,8 +151,14 @@
                             }
                         }
                         catch (e) {
-                            const { data, transferables } = (0, exports.serializer)(e, true);
-                            ev.data[0].postMessage([false, data], transferables);
+                            try {
+                                const { data, transferables } = (0, exports.serializer)(e, true);
+                                ev.data[0].postMessage([false, data], transferables);
+                            }
+                            catch (e) {
+                                console.error('Error on onmessage handler trying to transmit error', e);
+                                ev.data[0].postMessage([false]);
+                            }
                         }
                         ev.data[0].close();
                     }
@@ -247,17 +255,27 @@
                                 const rcvPort = mc.port1;
                                 const sendingPort = mc.port2;
                                 rcvPort.onmessage = (ev) => {
-                                    if (ev.data[0]) {
-                                        resolve((0, exports.deserializer)(ev.data[1]));
+                                    try {
+                                        if (ev.data[0]) {
+                                            resolve((0, exports.deserializer)(ev.data[1]));
+                                        }
+                                        else {
+                                            reject((0, exports.deserializer)(ev.data[1]));
+                                        }
                                     }
-                                    else {
-                                        reject((0, exports.deserializer)(ev.data[1]));
+                                    finally {
+                                        rcvPort.close();
+                                        revokables.forEach(port => port.close());
                                     }
-                                    rcvPort.close();
                                 };
                                 rcvPort.onmessageerror = () => {
-                                    reject(new Error('Message error'));
-                                    rcvPort.close();
+                                    try {
+                                        reject(new Error('Message error'));
+                                    }
+                                    finally {
+                                        rcvPort.close();
+                                        revokables.forEach(port => port.close());
+                                    }
                                 };
                                 try {
                                     mp.postMessage([sendingPort, data], [sendingPort, ...transferables]);

--- a/dist/umd/index.cjs
+++ b/dist/umd/index.cjs
@@ -59,147 +59,159 @@
         const revokables = new Set();
         // JSON.parse and JSON.stringify are called for their ability to do a deep
         // clone and calling a reviver / replacer.
-        const result = JSON.parse(JSON.stringify(data, (_key, value) => {
-            // Return already processed values without modifications
-            if (value && typeof value === 'object' && rawResultSet.has(value))
-                return value;
-            // Encode undefined as ['_', '_']
-            if (value === undefined)
-                return rawResult(rawResultSet, ['_', '_']);
-            // Encode falsy values as they are (JSON.stringify can handle these well,
-            // except undefined, which can't be represented in JSON)
-            if (!value)
-                return value;
-            // Arrays starting with '_' hold special (internal) meaning. If we receive
-            // such a value to encode, we prepend '_', '_' to ensure they are properly
-            // handled (this will be undone when deserializing)
-            if (Array.isArray(value) && value[0] === '_')
-                return rawResult(rawResultSet, ['_', '_', ...value]);
-            // If something is a Map, encode it as such. It needs to be broken down into
-            // an array so that elements they contain can also be processed, since JSON
-            // does not support Map
-            if (value instanceof Map) {
-                return rawResult(rawResultSet, ['_', 'Map', Array.from(value.entries())]);
-            }
-            // Same for Sets
-            if (value instanceof Set) {
-                return rawResult(rawResultSet, ['_', 'Set', Array.from(value.values())]);
-            }
-            // Error, Blob, File, etc. are supported by structuredClone but not by JSON
-            // We mark these as 'refs', so that the reviver can undo this transformation
-            if (value instanceof Blob || value instanceof File) {
-                const pos = verbatim.length;
-                verbatim[verbatim.length] = value;
-                return rawResult(rawResultSet, ['_', '_ref', pos]);
-            }
-            // However, Error cloning doesn't preserve `.name`
-            if (value instanceof Error) {
-                const obj = (() => {
-                    if (value.cause) {
-                        const causeCopy = value.cause;
-                        let serialized;
+        try {
+            const result = JSON.parse(JSON.stringify(data, (_key, value) => {
+                // Return already processed values without modifications
+                if (value && typeof value === 'object' && rawResultSet.has(value))
+                    return value;
+                // Encode undefined as ['_', '_']
+                if (value === undefined)
+                    return rawResult(rawResultSet, ['_', '_']);
+                // Encode falsy values as they are (JSON.stringify can handle these well,
+                // except undefined, which can't be represented in JSON)
+                if (!value)
+                    return value;
+                // Arrays starting with '_' hold special (internal) meaning. If we receive
+                // such a value to encode, we prepend '_', '_' to ensure they are properly
+                // handled (this will be undone when deserializing)
+                if (Array.isArray(value) && value[0] === '_')
+                    return rawResult(rawResultSet, ['_', '_', ...value]);
+                // If something is a Map, encode it as such. It needs to be broken down into
+                // an array so that elements they contain can also be processed, since JSON
+                // does not support Map
+                if (value instanceof Map) {
+                    return rawResult(rawResultSet, ['_', 'Map', Array.from(value.entries())]);
+                }
+                // Same for Sets
+                if (value instanceof Set) {
+                    return rawResult(rawResultSet, ['_', 'Set', Array.from(value.values())]);
+                }
+                // Error, Blob, File, etc. are supported by structuredClone but not by JSON
+                // We mark these as 'refs', so that the reviver can undo this transformation
+                if (value instanceof Blob || value instanceof File) {
+                    const pos = verbatim.length;
+                    verbatim[verbatim.length] = value;
+                    return rawResult(rawResultSet, ['_', '_ref', pos]);
+                }
+                // However, Error cloning doesn't preserve `.name`
+                if (value instanceof Error) {
+                    const obj = (() => {
+                        if (value.cause) {
+                            const causeCopy = value.cause;
+                            let serialized;
+                            try {
+                                // We need to also serialize `Error.cause` recursively
+                                // Do it on a copy so that the original object isn't destructively
+                                // modified
+                                // structuredClone will fail if `cause` has something that it doesn't
+                                // support
+                                serialized = (0, exports.serializer)(value.cause, true);
+                                value.cause = serialized.data;
+                                const copy = structuredClone(value);
+                                serialized.transferables.forEach(t => transferables.add(t));
+                                serialized.revokables.forEach(r => revokables.add(r));
+                                return copy;
+                            }
+                            catch (e) {
+                                console.error('Error serializing error cause', e);
+                                serialized?.revokables.forEach(r => r.close());
+                                // Add a fallback that preserves the error's key details
+                                const fallback = new Error(value.message);
+                                return fallback;
+                            }
+                            finally {
+                                value.cause = causeCopy;
+                            }
+                        }
+                        else {
+                            return value;
+                        }
+                    })();
+                    const pos = verbatim.length;
+                    verbatim[verbatim.length] = obj;
+                    return rawResult(rawResultSet, ['_', '_err', rawResult(rawResultSet, ['_', '_ref', pos]), value.name]);
+                }
+                // Same for other types supported by structuredClone but not JSON
+                if (value instanceof MessagePort || value instanceof ReadableStream || value instanceof WritableStream || value instanceof ArrayBuffer) {
+                    const pos = verbatim.length;
+                    verbatim[verbatim.length] = value;
+                    transferables.add(value);
+                    return rawResult(rawResultSet, ['_', '_ref', pos]);
+                }
+                if (ArrayBuffer.isView(value)) {
+                    const pos = verbatim.length;
+                    verbatim[verbatim.length] = value;
+                    if (!(typeof SharedArrayBuffer === 'function' && value.buffer instanceof SharedArrayBuffer)) {
+                        transferables.add(value.buffer);
+                    }
+                    return rawResult(rawResultSet, ['_', '_ref', pos]);
+                }
+                // Functions aren't supported neither by structuredClone nor JSON. However,
+                // we can convert functions into a MessagePort, which is supported
+                // To prevent memory leaks, it is important to fetch the `revokables` list
+                // and close ports when they are no longer needed.
+                if (typeof value === 'function' && !noFn) {
+                    const mc = new MessageChannel();
+                    mc.port1.onmessage = async (ev) => {
                         try {
-                            // We need to also serialize `Error.cause` recursively
-                            // Do it on a copy so that the original object isn't destructively
-                            // modified
-                            // structuredClone will fail if `cause` has something that it doesn't
-                            // support
-                            serialized = (0, exports.serializer)(value.cause, true);
-                            value.cause = serialized.data;
-                            const copy = structuredClone(value);
-                            serialized.transferables.forEach(t => transferables.add(t));
-                            serialized.revokables.forEach(r => revokables.add(r));
-                            return copy;
+                            try {
+                                const result = await value(...(0, exports.deserializer)(ev.data[1]));
+                                const { data, transferables, revokables } = (0, exports.serializer)(result);
+                                try {
+                                    ev.data[0].postMessage([true, data], transferables);
+                                }
+                                catch (e) {
+                                    revokables.forEach(port => port.close());
+                                    throw e;
+                                }
+                            }
+                            catch (e) {
+                                try {
+                                    const { data, transferables } = (0, exports.serializer)(e, true);
+                                    ev.data[0].postMessage([false, data], transferables);
+                                }
+                                catch (e) {
+                                    console.error('Error on onmessage handler trying to transmit error', e);
+                                    ev.data[0].postMessage([false]);
+                                }
+                            }
                         }
                         catch (e) {
-                            console.error('Error serializing error cause', e);
-                            serialized?.revokables.forEach(r => r.close());
+                            console.error('Async error on onmessage handler', e);
                         }
                         finally {
-                            value.cause = causeCopy;
+                            ev.data[0].close();
                         }
-                    }
-                    else {
-                        return value;
-                    }
-                })();
-                const pos = verbatim.length;
-                verbatim[verbatim.length] = obj || Error('Error');
-                return rawResult(rawResultSet, ['_', '_err', rawResult(rawResultSet, ['_', '_ref', pos]), value.name]);
-            }
-            // Same for other types supported by structuredClone but not JSON
-            if (value instanceof MessagePort || value instanceof ReadableStream || value instanceof WritableStream || value instanceof ArrayBuffer) {
-                const pos = verbatim.length;
-                verbatim[verbatim.length] = value;
-                transferables.add(value);
-                return rawResult(rawResultSet, ['_', '_ref', pos]);
-            }
-            if (ArrayBuffer.isView(value)) {
-                const pos = verbatim.length;
-                verbatim[verbatim.length] = value;
-                if (!(typeof SharedArrayBuffer === 'function' && value.buffer instanceof SharedArrayBuffer)) {
-                    transferables.add(value.buffer);
+                    };
+                    transferables.add(mc.port2);
+                    revokables.add(mc.port1);
+                    return rawResult(rawResultSet, ['_', '_fn', mc.port2]);
                 }
-                return rawResult(rawResultSet, ['_', '_ref', pos]);
-            }
-            // Functions aren't supported neither by structuredClone nor JSON. However,
-            // we can convert functions into a MessagePort, which is supported
-            // To prevent memory leaks, it is important to fetch the `revokables` list
-            // and close ports when they are no longer needed.
-            if (typeof value === 'function' && !noFn) {
-                const mc = new MessageChannel();
-                mc.port1.onmessage = async (ev) => {
-                    try {
-                        try {
-                            const result = await value(...(0, exports.deserializer)(ev.data[1]));
-                            const { data, transferables, revokables } = (0, exports.serializer)(result);
-                            try {
-                                ev.data[0].postMessage([true, data], transferables);
-                            }
-                            catch (e) {
-                                revokables.forEach(port => port.close());
-                                throw e;
-                            }
-                        }
-                        catch (e) {
-                            try {
-                                const { data, transferables } = (0, exports.serializer)(e, true);
-                                ev.data[0].postMessage([false, data], transferables);
-                            }
-                            catch (e) {
-                                console.error('Error on onmessage handler trying to transmit error', e);
-                                ev.data[0].postMessage([false]);
-                            }
-                        }
-                        ev.data[0].close();
-                    }
-                    catch (e) {
-                        console.error('Async error on onmessage handler', e);
-                    }
-                };
-                transferables.add(mc.port2);
-                revokables.add(mc.port1);
-                return rawResult(rawResultSet, ['_', '_fn', mc.port2]);
-            }
-            const proto = Object.getPrototypeOf(value);
-            // This allows encoding custom arbitrary objects (e.g., GIMessage)
-            if (proto?.constructor?.[exports.serdesTagSymbol] && proto.constructor[exports.serdesSerializeSymbol]) {
-                return rawResult(rawResultSet, ['_', '_custom', proto.constructor[exports.serdesTagSymbol], proto.constructor[exports.serdesSerializeSymbol](value)]);
-            }
-            return value;
-        }), (_key, value) => {
-            // Undo _ref transformations so that structuredClone can send the correct
-            // object
-            if (Array.isArray(value) && value[0] === '_' && value[1] === '_ref') {
-                return verbatim[value[2]];
-            }
-            return value;
-        });
-        return {
-            data: result,
-            transferables: Array.from(transferables),
-            revokables: Array.from(revokables)
-        };
+                const proto = Object.getPrototypeOf(value);
+                // This allows encoding custom arbitrary objects (e.g., GIMessage)
+                if (proto?.constructor?.[exports.serdesTagSymbol] && proto.constructor[exports.serdesSerializeSymbol]) {
+                    return rawResult(rawResultSet, ['_', '_custom', proto.constructor[exports.serdesTagSymbol], proto.constructor[exports.serdesSerializeSymbol](value)]);
+                }
+                return value;
+            }), (_key, value) => {
+                // Undo _ref transformations so that structuredClone can send the correct
+                // object
+                if (Array.isArray(value) && value[0] === '_' && value[1] === '_ref') {
+                    return verbatim[value[2]];
+                }
+                return value;
+            });
+            return {
+                data: result,
+                transferables: Array.from(transferables),
+                revokables: Array.from(revokables)
+            };
+        }
+        catch (e) {
+            // Prevent memory leaks if stringify aborts cleanly mid-traversal
+            revokables.forEach(port => port.close());
+            throw e;
+        }
     };
     exports.serializer = serializer;
     // Internal lookup table for registered deserializers

--- a/dist/umd/index.cjs
+++ b/dist/umd/index.cjs
@@ -37,7 +37,9 @@
         return obj;
     };
     // The `serializer` function prepares data before sending it as a message
-    const serializer = (data) => {
+    // The `noFn` boolean disables serializing functions, which helps with
+    // memory management.
+    const serializer = (data, noFn) => {
         const rawResultSet = new WeakSet();
         const verbatim = [];
         const transferables = new Set();
@@ -83,7 +85,7 @@
                 verbatim[verbatim.length] = value;
                 // We need to also serialize `Error.cause` recursively
                 if (value.cause) {
-                    value.cause = (0, exports.serializer)(value.cause).data;
+                    value.cause = (0, exports.serializer)(value.cause, true).data;
                 }
                 return rawResult(rawResultSet, ['_', '_err', rawResult(rawResultSet, ['_', '_ref', pos]), value.name]);
             }
@@ -94,7 +96,7 @@
                 transferables.add(value);
                 return rawResult(rawResultSet, ['_', '_ref', pos]);
             }
-            if (ArrayBuffer.isView(value)) {
+            if (ArrayBuffer.isView(value) && !(typeof SharedArrayBuffer !== 'function' || value.buffer instanceof SharedArrayBuffer)) {
                 const pos = verbatim.length;
                 verbatim[verbatim.length] = value;
                 transferables.add(value.buffer);
@@ -102,18 +104,22 @@
             }
             // Functions aren't supported neither by structuredClone nor JSON. However,
             // we can convert functions into a MessagePort, which is supported
-            if (typeof value === 'function') {
+            if (typeof value === 'function' && !noFn) {
                 const mc = new MessageChannel();
                 mc.port1.onmessage = async (ev) => {
                     try {
                         try {
                             const result = await value(...(0, exports.deserializer)(ev.data[1]));
-                            const { data, transferables } = (0, exports.serializer)(result);
+                            // TODO FIXME: This could still leave some ports open on functions
+                            // that return functions that return functions
+                            const { data, transferables, revokables: rr } = (0, exports.serializer)(result);
                             ev.data[0].postMessage([true, data], transferables);
+                            rr.forEach(r => revokables.add(r));
                         }
                         catch (e) {
-                            const { data, transferables } = (0, exports.serializer)(e);
+                            const { data, transferables, revokables: rr } = (0, exports.serializer)(e, true);
                             ev.data[0].postMessage([false, data], transferables);
+                            rr.forEach(r => revokables.add(r));
                         }
                     }
                     catch (e) {
@@ -205,6 +211,10 @@
                         return (...args) => {
                             return new Promise((resolve, reject) => {
                                 const mc = new MessageChannel();
+                                // TODO FIXME: Potential memory leak if any of the args is a
+                                // function that gets called. This level of nesting isn't
+                                // that common. A more comprehensive solution should nevertheless
+                                // be devised.
                                 const { data, transferables } = (0, exports.serializer)(args);
                                 mc.port1.onmessage = (ev) => {
                                     if (ev.data[0]) {

--- a/dist/umd/index.cjs
+++ b/dist/umd/index.cjs
@@ -37,7 +37,7 @@
         return obj;
     };
     const portDestructor = (() => {
-        if (typeof FinalizationRegistry !== 'function' || typeof WeakRef !== 'function') {
+        if (typeof FinalizationRegistry !== 'function') {
             return () => { };
         }
         const registry = new FinalizationRegistry((heldValue) => {
@@ -97,12 +97,23 @@
                 const obj = (() => {
                     if (value.cause) {
                         const causeCopy = value.cause;
+                        let serialized;
                         try {
                             // We need to also serialize `Error.cause` recursively
                             // Do it on a copy so that the original object isn't destructively
                             // modified
-                            value.cause = (0, exports.serializer)(value.cause, true).data;
-                            return structuredClone(value);
+                            // structuredClone will fail if `cause` has something that it doesn't
+                            // support
+                            serialized = (0, exports.serializer)(value.cause, true);
+                            value.cause = serialized.data;
+                            const copy = structuredClone(value);
+                            serialized.transferables.forEach(t => transferables.add(t));
+                            serialized.revokables.forEach(r => revokables.add(r));
+                            return copy;
+                        }
+                        catch (e) {
+                            console.error('Error serializing error cause', e);
+                            serialized?.revokables.forEach(r => r.close());
                         }
                         finally {
                             value.cause = causeCopy;
@@ -113,7 +124,7 @@
                     }
                 })();
                 const pos = verbatim.length;
-                verbatim[verbatim.length] = obj;
+                verbatim[verbatim.length] = obj || Error('Error');
                 return rawResult(rawResultSet, ['_', '_err', rawResult(rawResultSet, ['_', '_ref', pos]), value.name]);
             }
             // Same for other types supported by structuredClone but not JSON
@@ -260,8 +271,11 @@
                                             resolve((0, exports.deserializer)(ev.data[1]));
                                         }
                                         else {
-                                            reject((0, exports.deserializer)(ev.data[1]));
+                                            reject(ev.data.length > 1 ? (0, exports.deserializer)(ev.data[1]) : new Error('Message error'));
                                         }
+                                    }
+                                    catch (e) {
+                                        reject(e);
                                     }
                                     finally {
                                         rcvPort.close();

--- a/dist/umd/index.d.cts
+++ b/dist/umd/index.d.cts
@@ -3,7 +3,7 @@ export declare const serdesSerializeSymbol: unique symbol;
 export declare const serdesDeserializeSymbol: unique symbol;
 type Transferables = MessagePort | ReadableStream | WritableStream | ArrayBuffer | ArrayBufferView;
 type Revokables = MessagePort;
-export declare const serializer: (data: unknown) => {
+export declare const serializer: (data: unknown, noFn?: boolean) => {
     data: unknown;
     transferables: Transferables[];
     revokables: Revokables[];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "turtledash",
-  "version": "1.0.0",
+  "name": "@chelonia/serdes",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "turtledash",
-      "version": "1.0.0",
+      "name": "@chelonia/serdes",
+      "version": "1.0.1",
       "license": "MIT",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^8.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chelonia/serdes",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "main": "dist/umd/index.cjs",
   "module": "dist/esm/index.js",
@@ -19,7 +19,7 @@
     }
   },
   "scripts": {
-    "test": "node --import 'data:text/javascript,import { register } from \"node:module\"; import { pathToFileURL } from \"node:url\"; register(\"ts-node/esm\", pathToFileURL(\"./\"));' src/index.test.ts",
+    "test": "node --expose-gc --import 'data:text/javascript,import { register } from \"node:module\"; import { pathToFileURL } from \"node:url\"; register(\"ts-node/esm\", pathToFileURL(\"./\"));' src/index.test.ts",
     "build:esm": "tsc --project tsconfig.json --declaration && mv ./dist/esm/index.d.ts ./dist/esm/index.d.mts",
     "build:umd": "tsc --project tsconfig.umd.json --declaration && mv ./dist/umd/index.js ./dist/umd/index.cjs && mv ./dist/umd/index.d.ts ./dist/umd/index.d.cts",
     "build": "npm run build:esm && npm run build:umd",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     }
   },
   "scripts": {
-    "test": "npm run lint && node  --expose-gc --import 'data:text/javascript,import { register } from \"node:module\"; import { pathToFileURL } from \"node:url\"; register(\"ts-node/esm\", pathToFileURL(\"./\"));' src/index.test.ts",
+    "test": "npm run lint && node --expose-gc --import 'data:text/javascript,import { register } from \"node:module\"; import { pathToFileURL } from \"node:url\"; register(\"ts-node/esm\", pathToFileURL(\"./\"));' src/index.test.ts",
     "build:esm": "tsc --project tsconfig.json --declaration && mv ./dist/esm/index.d.ts ./dist/esm/index.d.mts",
     "build:umd": "tsc --project tsconfig.umd.json --declaration && mv ./dist/umd/index.js ./dist/umd/index.cjs && mv ./dist/umd/index.d.ts ./dist/umd/index.d.cts",
     "build": "npm run build:esm && npm run build:umd",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -3,9 +3,12 @@ import { describe, it, afterEach } from 'node:test'
 import * as _ from './index.js'
 
 describe('Test serdes', () => {
+  // Deno doesn't seem to have implemented `afterEach`
   try {
     afterEach(() => {
-      if (global.gc) {
+      // Explicitly call the garbage collector on Node. This makes the tests
+      // finish faster (otherwise, they hang until garbage collection occurs)
+      if (typeof global?.gc === 'function') {
         global.gc()
       }
     })
@@ -26,8 +29,10 @@ describe('Test serdes', () => {
   it('should not leak memory', async () => {
     // const values = []
     const serialized = _.serializer((callbackFactory: () => Promise<(x: () => string) => Promise<void>>) => {
-      callbackFactory().then(callback => callback(() => 'foo'))
-      return callbackFactory().then(callback => callback(() => 'bar'))
+      return Promise.all([
+        callbackFactory().then(callback => callback(() => 'foo')),
+        callbackFactory().then(callback => callback(() => 'bar'))
+      ])
     })
     const fn = _.deserializer(serialized.data) as (callback: () => (valueProvider: () => Promise<string>) => void) => void
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,8 +1,16 @@
 import * as assert from 'node:assert/strict'
-import { describe, it } from 'node:test'
+import { describe, it, afterEach } from 'node:test'
 import * as _ from './index.js'
 
 describe('Test serdes', () => {
+  try {
+    afterEach(() => {
+      if (global.gc) {
+        global.gc()
+      }
+    })
+  } catch {}
+
   it('should reconstruct basic object', () => {
     const source = {
       foo: '123',
@@ -13,5 +21,27 @@ describe('Test serdes', () => {
     }
     const result = _.deserializer(_.serializer(source).data)
     assert.deepEqual(result, source)
+  })
+
+  it('should not leak memory', async () => {
+    // const values = []
+    const serialized = _.serializer((callbackFactory: () => Promise<(x: () => string) => Promise<void>>) => {
+      callbackFactory().then(callback => callback(() => 'foo'))
+      return callbackFactory().then(callback => callback(() => 'bar'))
+    })
+    const fn = _.deserializer(serialized.data) as (callback: () => (valueProvider: () => Promise<string>) => void) => void
+
+    const results = [] as [string, string][]
+
+    await Promise.all([
+      fn(() => (valueProvider) => valueProvider().then(value => results.push(['cb1', value]))),
+      fn(() => (valueProvider) => valueProvider().then(value => results.push(['cb2', value])))
+    ])
+
+    assert.ok(results.length === 4)
+    assert.ok(results.some(([cb, str]) => cb === 'cb1' && str === 'foo'))
+    assert.ok(results.some(([cb, str]) => cb === 'cb1' && str === 'bar'))
+    assert.ok(results.some(([cb, str]) => cb === 'cb2' && str === 'foo'))
+    assert.ok(results.some(([cb, str]) => cb === 'cb2' && str === 'bar'))
   })
 })

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -8,11 +8,14 @@ describe('Test serdes', () => {
     afterEach(() => {
       // Explicitly call the garbage collector on Node. This makes the tests
       // finish faster (otherwise, they hang until garbage collection occurs)
-      if (typeof global?.gc === 'function') {
-        global.gc()
+      if (typeof gc === 'function') {
+        // eslint-disable-next-line no-undef
+        gc()
       }
     })
-  } catch {}
+  } catch {
+    // if afterEach fails, it's not a critical error
+  }
 
   it('should reconstruct basic object', () => {
     const source = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,19 +31,14 @@ const portDestructor = (() => {
   if (typeof FinalizationRegistry !== 'function' || typeof WeakRef !== 'function') {
     return () => {}
   }
-  const registry = new FinalizationRegistry((heldValue: () => void) => {
-    heldValue()
+  const registry = new FinalizationRegistry((heldValue: MessagePort) => {
+    heldValue.close()
   })
 
   // Automatic destruction (handled on the deserializing end):
   // When a returned proxy function goes out of scope, close its associated port
   return (fn: object, port: MessagePort) => {
-    // Using a weak reference to prevent leaking memory
-    const portWR = new WeakRef(port)
-    registry.register(fn, () => {
-      const port = portWR.deref()
-      port?.close()
-    })
+    registry.register(fn, port)
   }
 })()
 
@@ -96,12 +91,24 @@ export const serializer = (data: unknown, noFn?: boolean): {
     }
     // However, Error cloning doesn't preserve `.name`
     if (value instanceof Error) {
+      const obj = (() => {
+        if (value.cause) {
+          const causeCopy = value.cause
+          try {
+            // We need to also serialize `Error.cause` recursively
+            // Do it on a copy so that the original object isn't destructively
+            // modified
+            value.cause = serializer(value.cause, true).data
+            return structuredClone(value)
+          } finally {
+            value.cause = causeCopy
+          }
+        } else {
+          return value
+        }
+      })()
       const pos = verbatim.length
-      verbatim[verbatim.length] = value
-      // We need to also serialize `Error.cause` recursively
-      if (value.cause) {
-        value.cause = serializer(value.cause, true).data
-      }
+      verbatim[verbatim.length] = obj
       return rawResult(rawResultSet, ['_', '_err', rawResult(rawResultSet, ['_', '_ref', pos]), value.name])
     }
     // Same for other types supported by structuredClone but not JSON
@@ -127,8 +134,13 @@ export const serializer = (data: unknown, noFn?: boolean): {
         try {
           try {
             const result = await value(...deserializer(ev.data[1]) as unknown[])
-            const { data, transferables } = serializer(result)
-            ev.data[0].postMessage([true, data], transferables)
+            const { data, transferables, revokables } = serializer(result)
+            try {
+              ev.data[0].postMessage([true, data], transferables)
+            } catch (e) {
+              revokables.forEach(port => port.close())
+              throw e
+            }
           } catch (e) {
             const { data, transferables } = serializer(e, true)
             ev.data[0].postMessage([false, data], transferables)
@@ -223,7 +235,7 @@ export const deserializer = (data: unknown): unknown => {
           const fn = (...args: unknown[]) => {
             return new Promise((resolve, reject) => {
               const mc = new MessageChannel()
-              const { data, transferables } = serializer(args)
+              const { data, transferables, revokables } = serializer(args)
               const rcvPort = mc.port1
               const sendingPort = mc.port2
               rcvPort.onmessage = (ev) => {
@@ -242,6 +254,7 @@ export const deserializer = (data: unknown): unknown => {
                 mp.postMessage([sendingPort, data], [sendingPort, ...transferables])
               } catch (e) {
                 rcvPort.close()
+                revokables.forEach(port => port.close())
                 reject(e)
               }
             })

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,10 @@ const portDestructor = (() => {
     heldValue()
   })
 
+  // Automatric destruction (handled on the deserializing end):
+  // When a returned proxy function goes out of scope, close its associated port
   return (fn: object, port: MessagePort) => {
+    // Using a weak reference to prevent leaking memory
     const portWR = new WeakRef(port)
     registry.register(fn, () => {
       const port = portWR.deref()
@@ -116,6 +119,8 @@ export const serializer = (data: unknown, noFn?: boolean): {
     }
     // Functions aren't supported neither by structuredClone nor JSON. However,
     // we can convert functions into a MessagePort, which is supported
+    // To prevent memory leaks, it is important to fetch the `revokables` list
+    // and close ports when they are no longer needed.
     if (typeof value === 'function' && !noFn) {
       const mc = new MessageChannel()
       mc.port1.onmessage = async (ev) => {
@@ -236,6 +241,7 @@ export const deserializer = (data: unknown): unknown => {
               mp.postMessage([sendingPort, data], [sendingPort, ...transferables])
             })
           }
+          // Automatic clean up when the function goes out of scope
           portDestructor(fn, mp)
           return fn
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -164,9 +164,10 @@ export const serializer = (data: unknown, noFn?: boolean): {
               ev.data[0].postMessage([false])
             }
           }
-          ev.data[0].close()
         } catch (e) {
           console.error('Async error on onmessage handler', e)
+        } finally {
+          ev.data[0].close()
         }
       }
       transferables.add(mc.port2)

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,23 @@ const rawResult = <T extends object> (rawResultSet: WeakSet<T>, obj: T): T => {
   return obj
 }
 
+const portDestructor = (() => {
+  if (typeof FinalizationRegistry !== 'function' || typeof WeakRef !== 'function') {
+    return () => {}
+  }
+  const registry = new FinalizationRegistry((heldValue: () => void) => {
+    heldValue()
+  })
+
+  return (fn: object, port: MessagePort) => {
+    const portWR = new WeakRef(port)
+    registry.register(fn, () => {
+      const port = portWR.deref()
+      port?.close()
+    })
+  }
+})()
+
 type Transferables = MessagePort | ReadableStream | WritableStream | ArrayBuffer | ArrayBufferView
 type Verbatim = Transferables | Blob | File | Error
 type Revokables = MessagePort
@@ -91,10 +108,10 @@ export const serializer = (data: unknown, noFn?: boolean): {
       transferables.add(value)
       return rawResult(rawResultSet, ['_', '_ref', pos])
     }
-    if (ArrayBuffer.isView(value) && !(typeof SharedArrayBuffer !== 'function' || value.buffer instanceof SharedArrayBuffer)) {
+    if (ArrayBuffer.isView(value) && !(typeof SharedArrayBuffer !== 'function' && value.buffer instanceof SharedArrayBuffer)) {
       const pos = verbatim.length
       verbatim[verbatim.length] = value
-      transferables.add(value.buffer)
+      transferables.add(value.buffer as Transferables)
       return rawResult(rawResultSet, ['_', '_ref', pos])
     }
     // Functions aren't supported neither by structuredClone nor JSON. However,
@@ -105,16 +122,13 @@ export const serializer = (data: unknown, noFn?: boolean): {
         try {
           try {
             const result = await value(...deserializer(ev.data[1]) as unknown[])
-            // TODO FIXME: This could still leave some ports open on functions
-            // that return functions that return functions
-            const { data, transferables, revokables: rr } = serializer(result)
+            const { data, transferables } = serializer(result)
             ev.data[0].postMessage([true, data], transferables)
-            rr.forEach(r => revokables.add(r))
           } catch (e) {
-            const { data, transferables, revokables: rr } = serializer(e, true)
+            const { data, transferables } = serializer(e, true)
             ev.data[0].postMessage([false, data], transferables)
-            rr.forEach(r => revokables.add(r))
           }
+          ev.data[0].close()
         } catch (e) {
           console.error('Async error on onmessage handler', e)
         }
@@ -201,24 +215,29 @@ export const deserializer = (data: unknown): unknown => {
         // end back into functions using that port.
         case '_fn': {
           const mp = value[2]
-          return (...args: unknown[]) => {
+          const fn = (...args: unknown[]) => {
             return new Promise((resolve, reject) => {
               const mc = new MessageChannel()
-              // TODO FIXME: Potential memory leak if any of the args is a
-              // function that gets called. This level of nesting isn't
-              // that common. A more comprehensive solution should nevertheless
-              // be devised.
               const { data, transferables } = serializer(args)
-              mc.port1.onmessage = (ev) => {
+              const rcvPort = mc.port1
+              const sendingPort = mc.port2
+              rcvPort.onmessage = (ev) => {
                 if (ev.data[0]) {
                   resolve(deserializer(ev.data[1]))
                 } else {
                   reject(deserializer(ev.data[1]))
                 }
+                rcvPort.close()
               }
-              mp.postMessage([mc.port2, data], [mc.port2, ...transferables])
+              rcvPort.onmessageerror = () => {
+                reject(new Error('Messge error'))
+                rcvPort.close()
+              }
+              mp.postMessage([sendingPort, data], [sendingPort, ...transferables])
             })
           }
+          portDestructor(fn, mp)
+          return fn
         }
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ const rawResult = <T extends object> (rawResultSet: WeakSet<T>, obj: T): T => {
 }
 
 const portDestructor = (() => {
-  if (typeof FinalizationRegistry !== 'function' || typeof WeakRef !== 'function') {
+  if (typeof FinalizationRegistry !== 'function') {
     return () => {}
   }
   const registry = new FinalizationRegistry((heldValue: MessagePort) => {
@@ -94,12 +94,24 @@ export const serializer = (data: unknown, noFn?: boolean): {
       const obj = (() => {
         if (value.cause) {
           const causeCopy = value.cause
+          let serialized: ReturnType<typeof serializer> | undefined
           try {
             // We need to also serialize `Error.cause` recursively
             // Do it on a copy so that the original object isn't destructively
             // modified
-            value.cause = serializer(value.cause, true).data
-            return structuredClone(value)
+            // structuredClone will fail if `cause` has something that it doesn't
+            // support
+            serialized = serializer(value.cause, true)
+            value.cause = serialized.data
+            const copy = structuredClone(value)
+
+            serialized.transferables.forEach(t => transferables.add(t))
+            serialized.revokables.forEach(r => revokables.add(r))
+
+            return copy
+          } catch (e) {
+            console.error('Error serializing error cause', e)
+            serialized?.revokables.forEach(r => r.close())
           } finally {
             value.cause = causeCopy
           }
@@ -108,7 +120,7 @@ export const serializer = (data: unknown, noFn?: boolean): {
         }
       })()
       const pos = verbatim.length
-      verbatim[verbatim.length] = obj
+      verbatim[verbatim.length] = obj || Error('Error')
       return rawResult(rawResultSet, ['_', '_err', rawResult(rawResultSet, ['_', '_ref', pos]), value.name])
     }
     // Same for other types supported by structuredClone but not JSON
@@ -250,8 +262,10 @@ export const deserializer = (data: unknown): unknown => {
                   if (ev.data[0]) {
                     resolve(deserializer(ev.data[1]))
                   } else {
-                    reject(deserializer(ev.data[1]))
+                    reject(ev.data.length > 1 ? deserializer(ev.data[1]) : new Error('Message error'))
                   }
+                } catch (e) {
+                  reject(e)
                 } finally {
                   rcvPort.close()
                   revokables.forEach(port => port.close())

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,143 +60,149 @@ export const serializer = (data: unknown, noFn?: boolean): {
   const revokables = new Set<Revokables>()
   // JSON.parse and JSON.stringify are called for their ability to do a deep
   // clone and calling a reviver / replacer.
-  const result = JSON.parse(JSON.stringify(data, (_key: string, value: unknown) => {
+  try {
+    const result = JSON.parse(JSON.stringify(data, (_key: string, value: unknown) => {
     // Return already processed values without modifications
-    if (value && typeof value === 'object' && rawResultSet.has(value)) return value
-    // Encode undefined as ['_', '_']
-    if (value === undefined) return rawResult(rawResultSet, ['_', '_'])
-    // Encode falsy values as they are (JSON.stringify can handle these well,
-    // except undefined, which can't be represented in JSON)
-    if (!value) return value
-    // Arrays starting with '_' hold special (internal) meaning. If we receive
-    // such a value to encode, we prepend '_', '_' to ensure they are properly
-    // handled (this will be undone when deserializing)
-    if (Array.isArray(value) && value[0] === '_') return rawResult(rawResultSet, ['_', '_', ...value])
-    // If something is a Map, encode it as such. It needs to be broken down into
-    // an array so that elements they contain can also be processed, since JSON
-    // does not support Map
-    if (value instanceof Map) {
-      return rawResult(rawResultSet, ['_', 'Map', Array.from(value.entries())])
-    }
-    // Same for Sets
-    if (value instanceof Set) {
-      return rawResult(rawResultSet, ['_', 'Set', Array.from(value.values())])
-    }
-    // Error, Blob, File, etc. are supported by structuredClone but not by JSON
-    // We mark these as 'refs', so that the reviver can undo this transformation
-    if (value instanceof Blob || value instanceof File) {
-      const pos = verbatim.length
-      verbatim[verbatim.length] = value
-      return rawResult(rawResultSet, ['_', '_ref', pos])
-    }
-    // However, Error cloning doesn't preserve `.name`
-    if (value instanceof Error) {
-      const obj = (() => {
-        if (value.cause) {
-          const causeCopy = value.cause
-          let serialized: ReturnType<typeof serializer> | undefined
-          try {
+      if (value && typeof value === 'object' && rawResultSet.has(value)) return value
+      // Encode undefined as ['_', '_']
+      if (value === undefined) return rawResult(rawResultSet, ['_', '_'])
+      // Encode falsy values as they are (JSON.stringify can handle these well,
+      // except undefined, which can't be represented in JSON)
+      if (!value) return value
+      // Arrays starting with '_' hold special (internal) meaning. If we receive
+      // such a value to encode, we prepend '_', '_' to ensure they are properly
+      // handled (this will be undone when deserializing)
+      if (Array.isArray(value) && value[0] === '_') return rawResult(rawResultSet, ['_', '_', ...value])
+      // If something is a Map, encode it as such. It needs to be broken down into
+      // an array so that elements they contain can also be processed, since JSON
+      // does not support Map
+      if (value instanceof Map) {
+        return rawResult(rawResultSet, ['_', 'Map', Array.from(value.entries())])
+      }
+      // Same for Sets
+      if (value instanceof Set) {
+        return rawResult(rawResultSet, ['_', 'Set', Array.from(value.values())])
+      }
+      // Error, Blob, File, etc. are supported by structuredClone but not by JSON
+      // We mark these as 'refs', so that the reviver can undo this transformation
+      if (value instanceof Blob || value instanceof File) {
+        const pos = verbatim.length
+        verbatim[verbatim.length] = value
+        return rawResult(rawResultSet, ['_', '_ref', pos])
+      }
+      // However, Error cloning doesn't preserve `.name`
+      if (value instanceof Error) {
+        const obj = (() => {
+          if (value.cause) {
+            const causeCopy = value.cause
+            let serialized: ReturnType<typeof serializer> | undefined
+            try {
             // We need to also serialize `Error.cause` recursively
             // Do it on a copy so that the original object isn't destructively
             // modified
             // structuredClone will fail if `cause` has something that it doesn't
             // support
-            serialized = serializer(value.cause, true)
-            value.cause = serialized.data
-            const copy = structuredClone(value)
+              serialized = serializer(value.cause, true)
+              value.cause = serialized.data
+              const copy = structuredClone(value)
 
-            serialized.transferables.forEach(t => transferables.add(t))
-            serialized.revokables.forEach(r => revokables.add(r))
+              serialized.transferables.forEach(t => transferables.add(t))
+              serialized.revokables.forEach(r => revokables.add(r))
 
-            return copy
-          } catch (e) {
-            console.error('Error serializing error cause', e)
-            serialized?.revokables.forEach(r => r.close())
+              return copy
+            } catch (e) {
+              console.error('Error serializing error cause', e)
+              serialized?.revokables.forEach(r => r.close())
 
-            // Add a fallback that preserves the error's key details
-            const fallback = new Error(value.message)
-            return fallback
-          } finally {
-            value.cause = causeCopy
+              // Add a fallback that preserves the error's key details
+              const fallback = new Error(value.message)
+              return fallback
+            } finally {
+              value.cause = causeCopy
+            }
+          } else {
+            return value
           }
-        } else {
-          return value
-        }
-      })()
-      const pos = verbatim.length
-      verbatim[verbatim.length] = obj
-      return rawResult(rawResultSet, ['_', '_err', rawResult(rawResultSet, ['_', '_ref', pos]), value.name])
-    }
-    // Same for other types supported by structuredClone but not JSON
-    if (value instanceof MessagePort || value instanceof ReadableStream || value instanceof WritableStream || value instanceof ArrayBuffer) {
-      const pos = verbatim.length
-      verbatim[verbatim.length] = value
-      transferables.add(value)
-      return rawResult(rawResultSet, ['_', '_ref', pos])
-    }
-    if (ArrayBuffer.isView(value)) {
-      const pos = verbatim.length
-      verbatim[verbatim.length] = value
-      if (!(typeof SharedArrayBuffer === 'function' && value.buffer instanceof SharedArrayBuffer)) {
-        transferables.add(value.buffer as Transferables)
+        })()
+        const pos = verbatim.length
+        verbatim[verbatim.length] = obj
+        return rawResult(rawResultSet, ['_', '_err', rawResult(rawResultSet, ['_', '_ref', pos]), value.name])
       }
-      return rawResult(rawResultSet, ['_', '_ref', pos])
-    }
-    // Functions aren't supported neither by structuredClone nor JSON. However,
-    // we can convert functions into a MessagePort, which is supported
-    // To prevent memory leaks, it is important to fetch the `revokables` list
-    // and close ports when they are no longer needed.
-    if (typeof value === 'function' && !noFn) {
-      const mc = new MessageChannel()
-      mc.port1.onmessage = async (ev) => {
-        try {
+      // Same for other types supported by structuredClone but not JSON
+      if (value instanceof MessagePort || value instanceof ReadableStream || value instanceof WritableStream || value instanceof ArrayBuffer) {
+        const pos = verbatim.length
+        verbatim[verbatim.length] = value
+        transferables.add(value)
+        return rawResult(rawResultSet, ['_', '_ref', pos])
+      }
+      if (ArrayBuffer.isView(value)) {
+        const pos = verbatim.length
+        verbatim[verbatim.length] = value
+        if (!(typeof SharedArrayBuffer === 'function' && value.buffer instanceof SharedArrayBuffer)) {
+          transferables.add(value.buffer as Transferables)
+        }
+        return rawResult(rawResultSet, ['_', '_ref', pos])
+      }
+      // Functions aren't supported neither by structuredClone nor JSON. However,
+      // we can convert functions into a MessagePort, which is supported
+      // To prevent memory leaks, it is important to fetch the `revokables` list
+      // and close ports when they are no longer needed.
+      if (typeof value === 'function' && !noFn) {
+        const mc = new MessageChannel()
+        mc.port1.onmessage = async (ev) => {
           try {
-            const result = await value(...deserializer(ev.data[1]) as unknown[])
-            const { data, transferables, revokables } = serializer(result)
             try {
-              ev.data[0].postMessage([true, data], transferables)
+              const result = await value(...deserializer(ev.data[1]) as unknown[])
+              const { data, transferables, revokables } = serializer(result)
+              try {
+                ev.data[0].postMessage([true, data], transferables)
+              } catch (e) {
+                revokables.forEach(port => port.close())
+                throw e
+              }
             } catch (e) {
-              revokables.forEach(port => port.close())
-              throw e
+              try {
+                const { data, transferables } = serializer(e, true)
+                ev.data[0].postMessage([false, data], transferables)
+              } catch (e) {
+                console.error('Error on onmessage handler trying to transmit error', e)
+                ev.data[0].postMessage([false])
+              }
             }
           } catch (e) {
-            try {
-              const { data, transferables } = serializer(e, true)
-              ev.data[0].postMessage([false, data], transferables)
-            } catch (e) {
-              console.error('Error on onmessage handler trying to transmit error', e)
-              ev.data[0].postMessage([false])
-            }
+            console.error('Async error on onmessage handler', e)
+          } finally {
+            ev.data[0].close()
           }
-        } catch (e) {
-          console.error('Async error on onmessage handler', e)
-        } finally {
-          ev.data[0].close()
         }
+        transferables.add(mc.port2)
+        revokables.add(mc.port1)
+        return rawResult(rawResultSet, ['_', '_fn', mc.port2])
       }
-      transferables.add(mc.port2)
-      revokables.add(mc.port1)
-      return rawResult(rawResultSet, ['_', '_fn', mc.port2])
-    }
-    const proto = Object.getPrototypeOf(value)
-    // This allows encoding custom arbitrary objects (e.g., GIMessage)
-    if (proto?.constructor?.[serdesTagSymbol] && proto.constructor[serdesSerializeSymbol]) {
-      return rawResult(rawResultSet, ['_', '_custom', proto.constructor[serdesTagSymbol], proto.constructor[serdesSerializeSymbol](value)])
-    }
-    return value
-  }), (_key: string, value: unknown) => {
+      const proto = Object.getPrototypeOf(value)
+      // This allows encoding custom arbitrary objects (e.g., GIMessage)
+      if (proto?.constructor?.[serdesTagSymbol] && proto.constructor[serdesSerializeSymbol]) {
+        return rawResult(rawResultSet, ['_', '_custom', proto.constructor[serdesTagSymbol], proto.constructor[serdesSerializeSymbol](value)])
+      }
+      return value
+    }), (_key: string, value: unknown) => {
     // Undo _ref transformations so that structuredClone can send the correct
     // object
-    if (Array.isArray(value) && value[0] === '_' && value[1] === '_ref') {
-      return verbatim[value[2]]
-    }
-    return value
-  })
+      if (Array.isArray(value) && value[0] === '_' && value[1] === '_ref') {
+        return verbatim[value[2]]
+      }
+      return value
+    })
 
-  return {
-    data: result,
-    transferables: Array.from(transferables),
-    revokables: Array.from(revokables)
+    return {
+      data: result,
+      transferables: Array.from(transferables),
+      revokables: Array.from(revokables)
+    }
+  } catch (e) {
+    // Prevent memory leaks if stringify aborts cleanly mid-traversal
+    revokables.forEach(port => port.close())
+    throw e
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,10 +118,12 @@ export const serializer = (data: unknown, noFn?: boolean): {
       transferables.add(value)
       return rawResult(rawResultSet, ['_', '_ref', pos])
     }
-    if (ArrayBuffer.isView(value) && !(typeof SharedArrayBuffer === 'function' && value.buffer instanceof SharedArrayBuffer)) {
+    if (ArrayBuffer.isView(value)) {
       const pos = verbatim.length
       verbatim[verbatim.length] = value
-      transferables.add(value.buffer as Transferables)
+      if (!(typeof SharedArrayBuffer === 'function' && value.buffer instanceof SharedArrayBuffer)) {
+        transferables.add(value.buffer as Transferables)
+      }
       return rawResult(rawResultSet, ['_', '_ref', pos])
     }
     // Functions aren't supported neither by structuredClone nor JSON. However,
@@ -142,8 +144,13 @@ export const serializer = (data: unknown, noFn?: boolean): {
               throw e
             }
           } catch (e) {
-            const { data, transferables } = serializer(e, true)
-            ev.data[0].postMessage([false, data], transferables)
+            try {
+              const { data, transferables } = serializer(e, true)
+              ev.data[0].postMessage([false, data], transferables)
+            } catch (e) {
+              console.error('Error on onmessage handler trying to transmit error', e)
+              ev.data[0].postMessage([false])
+            }
           }
           ev.data[0].close()
         } catch (e) {
@@ -239,16 +246,24 @@ export const deserializer = (data: unknown): unknown => {
               const rcvPort = mc.port1
               const sendingPort = mc.port2
               rcvPort.onmessage = (ev) => {
-                if (ev.data[0]) {
-                  resolve(deserializer(ev.data[1]))
-                } else {
-                  reject(deserializer(ev.data[1]))
+                try {
+                  if (ev.data[0]) {
+                    resolve(deserializer(ev.data[1]))
+                  } else {
+                    reject(deserializer(ev.data[1]))
+                  }
+                } finally {
+                  rcvPort.close()
+                  revokables.forEach(port => port.close())
                 }
-                rcvPort.close()
               }
               rcvPort.onmessageerror = () => {
-                reject(new Error('Message error'))
-                rcvPort.close()
+                try {
+                  reject(new Error('Message error'))
+                } finally {
+                  rcvPort.close()
+                  revokables.forEach(port => port.close())
+                }
               }
               try {
                 mp.postMessage([sendingPort, data], [sendingPort, ...transferables])

--- a/src/index.ts
+++ b/src/index.ts
@@ -112,6 +112,10 @@ export const serializer = (data: unknown, noFn?: boolean): {
           } catch (e) {
             console.error('Error serializing error cause', e)
             serialized?.revokables.forEach(r => r.close())
+
+            // Add a fallback that preserves the error's key details
+            const fallback = new Error(value.message)
+            return fallback
           } finally {
             value.cause = causeCopy
           }
@@ -120,7 +124,7 @@ export const serializer = (data: unknown, noFn?: boolean): {
         }
       })()
       const pos = verbatim.length
-      verbatim[verbatim.length] = obj || Error('Error')
+      verbatim[verbatim.length] = obj
       return rawResult(rawResultSet, ['_', '_err', rawResult(rawResultSet, ['_', '_ref', pos]), value.name])
     }
     // Same for other types supported by structuredClone but not JSON

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ const portDestructor = (() => {
     heldValue()
   })
 
-  // Automatric destruction (handled on the deserializing end):
+  // Automatic destruction (handled on the deserializing end):
   // When a returned proxy function goes out of scope, close its associated port
   return (fn: object, port: MessagePort) => {
     // Using a weak reference to prevent leaking memory
@@ -111,7 +111,7 @@ export const serializer = (data: unknown, noFn?: boolean): {
       transferables.add(value)
       return rawResult(rawResultSet, ['_', '_ref', pos])
     }
-    if (ArrayBuffer.isView(value) && !(typeof SharedArrayBuffer !== 'function' && value.buffer instanceof SharedArrayBuffer)) {
+    if (ArrayBuffer.isView(value) && !(typeof SharedArrayBuffer === 'function' && value.buffer instanceof SharedArrayBuffer)) {
       const pos = verbatim.length
       verbatim[verbatim.length] = value
       transferables.add(value.buffer as Transferables)
@@ -235,10 +235,15 @@ export const deserializer = (data: unknown): unknown => {
                 rcvPort.close()
               }
               rcvPort.onmessageerror = () => {
-                reject(new Error('Messge error'))
+                reject(new Error('Message error'))
                 rcvPort.close()
               }
-              mp.postMessage([sendingPort, data], [sendingPort, ...transferables])
+              try {
+                mp.postMessage([sendingPort, data], [sendingPort, ...transferables])
+              } catch (e) {
+                rcvPort.close()
+                reject(e)
+              }
             })
           }
           // Automatic clean up when the function goes out of scope

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,9 @@ type Verbatim = Transferables | Blob | File | Error
 type Revokables = MessagePort
 
 // The `serializer` function prepares data before sending it as a message
-export const serializer = (data: unknown): {
+// The `noFn` boolean disables serializing functions, which helps with
+// memory management.
+export const serializer = (data: unknown, noFn?: boolean): {
     data: unknown,
     transferables: Transferables[],
     revokables: Revokables[]
@@ -78,7 +80,7 @@ export const serializer = (data: unknown): {
       verbatim[verbatim.length] = value
       // We need to also serialize `Error.cause` recursively
       if (value.cause) {
-        value.cause = serializer(value.cause).data
+        value.cause = serializer(value.cause, true).data
       }
       return rawResult(rawResultSet, ['_', '_err', rawResult(rawResultSet, ['_', '_ref', pos]), value.name])
     }
@@ -89,7 +91,7 @@ export const serializer = (data: unknown): {
       transferables.add(value)
       return rawResult(rawResultSet, ['_', '_ref', pos])
     }
-    if (ArrayBuffer.isView(value)) {
+    if (ArrayBuffer.isView(value) && !(typeof SharedArrayBuffer !== 'function' || value.buffer instanceof SharedArrayBuffer)) {
       const pos = verbatim.length
       verbatim[verbatim.length] = value
       transferables.add(value.buffer)
@@ -97,17 +99,21 @@ export const serializer = (data: unknown): {
     }
     // Functions aren't supported neither by structuredClone nor JSON. However,
     // we can convert functions into a MessagePort, which is supported
-    if (typeof value === 'function') {
+    if (typeof value === 'function' && !noFn) {
       const mc = new MessageChannel()
       mc.port1.onmessage = async (ev) => {
         try {
           try {
             const result = await value(...deserializer(ev.data[1]) as unknown[])
-            const { data, transferables } = serializer(result)
+            // TODO FIXME: This could still leave some ports open on functions
+            // that return functions that return functions
+            const { data, transferables, revokables: rr } = serializer(result)
             ev.data[0].postMessage([true, data], transferables)
+            rr.forEach(r => revokables.add(r))
           } catch (e) {
-            const { data, transferables } = serializer(e)
+            const { data, transferables, revokables: rr } = serializer(e, true)
             ev.data[0].postMessage([false, data], transferables)
+            rr.forEach(r => revokables.add(r))
           }
         } catch (e) {
           console.error('Async error on onmessage handler', e)
@@ -198,6 +204,10 @@ export const deserializer = (data: unknown): unknown => {
           return (...args: unknown[]) => {
             return new Promise((resolve, reject) => {
               const mc = new MessageChannel()
+              // TODO FIXME: Potential memory leak if any of the args is a
+              // function that gets called. This level of nesting isn't
+              // that common. A more comprehensive solution should nevertheless
+              // be devised.
               const { data, transferables } = serializer(args)
               mc.port1.onmessage = (ev) => {
                 if (ev.data[0]) {


### PR DESCRIPTION
Closes #1

The issue with the memory leak is as follows (this is the rationale behind why there was a memory leak and the fix):

1. It's convenient to have functions to be passed across boundaries (e.g., from the app to the SW). For example, a hook or a callback function.
2. However, `structuredClone` does _not_ support passing in functions. It _does_ allow passing in `MessagePort`s, which we can use to proxy functions.
3. These `MessagePort`s weren't being cleaned up. `serializer` returns a list of `revokables` that was being ignored (now they're closed in https://github.com/okTurtles/group-income/pull/3037).

## Why things were the were they were

Normally and conventionally, JavaScript functions don't have a 'lifetime' associated with them, other than going out of scope (like most other JavaScript objects). Closing the port amounts to adding an explicit lifetime to the function.

## Why the one-liner solution was rejected

The LLM suggestion of closing the port once the function call resolves is suboptimal because it'd mean that the function can only be called once.

## What was done instead

In https://github.com/okTurtles/group-income/pull/3037, the list of `revokables` is used to clean up ports after the main call succeeds. This still adds an explicit lifetime, but allows for proxied function arguments to be called multiple times.

In this PR:

* The list `revokables` is extended to include a few more message ports
* Added an argument to disable function proxying entirely. This avoids leaks before they can even happen, and is a good way to prevent them in cases where the caller (the one calling `serializer`) isn't sending or shouldn't be sending any functions.
